### PR TITLE
add missing return types

### DIFF
--- a/src/DrupalIssueForkCommand.php
+++ b/src/DrupalIssueForkCommand.php
@@ -23,7 +23,7 @@ class DrupalIssueForkCommand extends BaseCommand
             ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         if (!preg_match('#(?P<url>https://git.drupalcode.org/issue/(?P<project>.*)-\d+)/-/tree/(?P<branch>.*)$#', $input->getArgument('fork-url'), $matches)) {

--- a/src/DrupalIssueUnForkCommand.php
+++ b/src/DrupalIssueUnForkCommand.php
@@ -23,7 +23,7 @@ class DrupalIssueUnForkCommand extends DrupalIssueForkCommand
             ]);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         $project = $input->getArgument('drupal-project');


### PR DESCRIPTION
Thanks for making it easy to create forks of modules!

Return type hints needs to be added for Symfony 7 compatibility.  My CI builds (in PlatformSH) are failing with this error:

```
Return type declaration must be compatible with Command->execute(input: \Symfony\Component\Console\Input\InputInterface, output: \Symfony\Component\Console\Output\OutputInterface) : int
```

This PR adds the missing return type hints.